### PR TITLE
Speculative Generation e2e

### DIFF
--- a/fms_extras/models/speculator.py
+++ b/fms_extras/models/speculator.py
@@ -1,5 +1,5 @@
 import math
-from typing import List
+from typing import List, Tuple
 
 import torch
 import torch.nn as nn
@@ -170,3 +170,94 @@ class MLPSpeculator(nn.Module):
             state = self.activation(self.ln[i](state))  # b n d
             out.append(self.head[i](state))  # b n v
         return torch.stack(out, dim=0)  # h b n v
+
+
+def select_inflate_dim(
+    inp: torch.Tensor, inds: torch.Tensor, dim: int = 0
+) -> torch.Tensor:
+    """
+    Takes an input of size ([...], n, [...]), with n in slot corresponding to value of dim,
+    and tensor of indices of size (a, ..., z). Using those indices we over/under sample the
+    input on dimension n, to create output tensor with size ([...], (a, ..., z), [...]).
+
+    i.e. if dim=0, inp has size (6,3,2), and inds has size (8,4), then:
+    1) max(inds) < 6
+    2) output has size (8,4,3,2)
+
+    Args:
+        inp: torch.Tensor
+            tensor of inputs
+        inds: torch.Tensor
+            tensor of indices
+        dim: int
+            dimension to sample on
+
+    Returns:
+        torch.Tensor
+            output tensor with new size ([...], (a, ..., z), [...])
+    """
+    inds_shape = inds.size()
+    inp_shape = inp.size()
+    out = inp.index_select(dim, inds.view(-1))
+    return out.view(*inp_shape[:dim], *inds_shape, *inp_shape[dim + 1 :])
+
+
+def flatten_batch(inp: torch.Tensor) -> Tuple[torch.Tensor, torch.Tensor, torch.Tensor]:
+    """
+    Takes a speculator suffix tree: a bsize x n_candidates x candidate_len rectangular batch
+    of token indices, and flattens it while removing redundant tokens.
+
+    For example, given:
+
+    a b c
+    a b d
+    a e f
+
+    Tokens 'a b' in line 2 and token 'a' in line 3 are functionally equivalent to 'a b' in
+    line 1, so the flattened batch returns `a b c d e f`
+
+    Args:
+        inp: torch.Tensor
+            speculator suffix tree
+
+    Returns:
+        Tuple[torch.Tensor, torch.Tensor, torch.Tensor]
+            1) the flattened, pruned input
+            2) a tensor, sized as input, mapping each input token to its slot in output
+            3) a tensor, sized as output, mapping each output token to its slot in the flattened input
+    """
+    ind_out = torch.zeros_like(inp)
+    inp_list = inp.tolist()
+    out = []
+    ind_flat = []
+    batch_offset = 0
+    for b, candidate_set in enumerate(inp_list):
+        lineages: List[Tuple[List[int]]] = []
+        for k, candidate in enumerate(candidate_set):
+            for n in range(len(candidate)):
+                lineage = tuple(candidate[: n + 1])
+                if lineage in lineages:
+                    # Token is redundant
+                    ind_out[b, k, n] = lineages.index(lineage) + batch_offset
+                else:
+                    # Token is not redundant
+                    ind_out[b, k, n] = len(lineages) + batch_offset
+                    lineages.append(lineage)
+                    ind_flat.append(
+                        b * len(inp_list[0]) * len(inp_list[0][0])
+                        + k * len(inp_list[0][0])
+                        + n
+                    )
+        out.append(
+            torch.tensor(
+                [lineage[-1] for lineage in lineages],
+                device=ind_out.device,
+                dtype=torch.int32,
+            )
+        )
+        batch_offset += len(lineages)
+    return (
+        torch.cat(out),
+        ind_out,
+        torch.tensor(ind_flat, device=ind_out.device, dtype=torch.int32),
+    )

--- a/fms_extras/utils/cache/paged.py
+++ b/fms_extras/utils/cache/paged.py
@@ -9,6 +9,7 @@ import torch._inductor.lowering as lowering
 from torch._dynamo import mark_static_address
 from torch._inductor.virtualized import V
 
+from fms_extras.models.speculator import select_inflate_dim
 from fms_extras.paged_c import attn_ops, cache_ops  # type: ignore
 from fms_extras.utils.cache import CacheDataLayer, CacheDataWithMetadata, KVCache
 
@@ -290,6 +291,9 @@ class PagedAttentionCacheDataLayer(CacheDataLayer):
     kv_heads: int
     head_size: int
     is_generating: bool
+    query_length: int
+    flatten_indices: Optional[torch.Tensor] = None
+    unflatten_indices: Optional[torch.Tensor] = None
 
     def get_cache_type(self) -> str:
         return "paged-attention"
@@ -297,8 +301,22 @@ class PagedAttentionCacheDataLayer(CacheDataLayer):
     def store(
         self, keys: torch.Tensor, values: torch.Tensor
     ) -> Tuple[torch.Tensor, torch.Tensor]:
-        key_to_cache = keys.view(-1, self.kv_heads, self.head_size)
-        value_to_cache = values.view(-1, self.kv_heads, self.head_size)
+        # in the case where the indices have been flattened for performance purposes, we must unflatten them to the
+        # format expected in the reshape_and_cache function
+        if self.unflatten_indices is not None:
+            # inp: n' h d
+            # inds: b k n
+            # if we have a batch, it will be size 1 here, so will need to be removed, otherwise no-op
+            keys = keys.squeeze(0)
+            values = values.squeeze(0)
+
+            keys = select_inflate_dim(keys, self.unflatten_indices)  # b k n h d
+            values = select_inflate_dim(values, self.unflatten_indices)
+            key_to_cache = keys.view(-1, *keys.size()[3:])
+            value_to_cache = values.view(-1, *values.size()[3:])  # bkn h d
+        else:
+            key_to_cache = keys.view(-1, self.kv_heads, self.head_size)
+            value_to_cache = values.view(-1, self.kv_heads, self.head_size)
 
         self.data_layer = torch.ops.paged_attention.reshape_and_cache(
             key_to_cache,
@@ -411,6 +429,9 @@ class PagedAttentionCacheData(CacheDataWithMetadata):
     head_size: int
     is_generating: bool
     sequence_ids: List[int]
+    query_length: int
+    flatten_indices: Optional[torch.Tensor] = None
+    unflatten_indices: Optional[torch.Tensor] = None
 
     def get_layer(self, layer_index: int) -> PagedAttentionCacheDataLayer:
         return PagedAttentionCacheDataLayer(
@@ -425,6 +446,9 @@ class PagedAttentionCacheData(CacheDataWithMetadata):
             kv_heads=self.kv_heads,
             head_size=self.head_size,
             is_generating=self.is_generating,
+            query_length=self.query_length,
+            flatten_indices=self.flatten_indices,
+            unflatten_indices=self.unflatten_indices,
         )
 
     def is_filled(self) -> bool:
@@ -955,6 +979,9 @@ class PagedKVCacheManager:
             head_size=self.head_size,
             is_generating=not is_prompt,
             sequence_ids=sequence_ids,
+            query_length=0
+            if max_num_tokens_per_sequence is None
+            else max_num_tokens_per_sequence,
         )
 
     def allocate_tokens(

--- a/fms_extras/utils/generation.py
+++ b/fms_extras/utils/generation.py
@@ -5,7 +5,305 @@ from typing import Any, Callable, List, MutableMapping, Optional, Union
 import torch
 import torch.nn.functional as F
 
-from fms_extras.utils.cache.paged import PagedKVCacheManager
+from fms_extras.models.speculator import (
+    MLPSpeculator,
+    flatten_batch,
+    select_inflate_dim,
+)
+from fms_extras.utils.cache.paged import PagedAttentionCacheData, PagedKVCacheManager
+
+
+def speculative_generate(
+    model: Union[Callable, torch.nn.Module],
+    input_ids: Union[torch.Tensor, List[torch.Tensor]],
+    speculator: MLPSpeculator,
+    kv_cache_manager: PagedKVCacheManager,
+    max_seq_len: int = 2048,
+    new_tokens: int = 256,
+    n_candidates: int = 5,
+    threshes=[5, 3, 2],
+    flatting=True,
+    decode_model: Optional[Union[Callable, torch.nn.Module]] = None,
+    # todo: This is a WIP to enable cudagraphs, currently its only for batch_size=1
+    cudagraphs: bool = False,
+):
+    """
+    A reference implementation of speculative decoding generation.
+    Returns at least the specified number of tokens - the speculator may return a
+    few extra in the final step.
+    If input is batched, continues generating until EVERY sequence has produced AT LEAST the required number of tokens.
+    Input (and output) tokens beyond max_seq_len are simply dropped for a sliding-window approach.
+    Currently reproduces behavior of greedy decoding only.
+    Args:
+        model: A function or nn.Module that takes a batch of input_ids and
+            returns logits
+        input_ids: A length n tensor of token IDs, or list of such tensors
+        speculator: A function or nn.Module that takes a state vector and sampled token
+            and returns a set of candidate suffixes
+        kv_cache_manager: PagedKVCacheManager
+            the paged kv-cache manager to be used in generation
+        max_seq_len: the sequence length of the base model
+        new_tokens: number of tokens to generate
+        n_candidates: only consider the top n most confident candidates from the speculator
+        threshes: build candidate suffix trees by taking top-(threshes[n]) most confident values
+            for head n. len(threshes) must equal speculator.n_predict. prod(threshes) must be greater
+            than or equal to n_candidates (we cannot have more candidates than tree leaves).
+        flatting: enable batch flattening / tree attention with redundant prefix removal when compression
+            ratio is favorable. Adds extra overhead to shrink the token count in each batch.
+        decode_model: TODO
+        cudagraphs: TODO
+    Returns:
+        result: List of id tensors, possibly different lengths if batching.
+        n_steps: Number of foward passes used to generate provided tokens.
+    """
+    # Construct batch(es) and initial inputs
+    if decode_model is None:
+        decode_model = model
+    bsize = len(input_ids)
+
+    if cudagraphs and (flatting or bsize != 1):
+        raise NotImplementedError(
+            "cudagraphs is not yet supported for batch sizes greater than 1 or flatting"
+        )
+
+    result = input_ids  # [b] n
+
+    # Build padded batched input tensor
+    max_len = max([seq.size(0) for seq in input_ids])
+    n_pads_init = [max_len - seq.size(0) for seq in input_ids]
+    n_pads = torch.tensor(n_pads_init).to(device=input_ids[0].device, dtype=torch.int)
+    inputs = torch.stack(
+        [F.pad(input_ids[i], (n_pads_init[i], 0)) for i in range(bsize)]
+    )
+    num_tokens_per_sequence = torch.count_nonzero(inputs.T, dim=0).tolist()
+    cache_data: PagedAttentionCacheData = kv_cache_manager.allocate_tokens(
+        num_tokens_per_sequence
+    )
+    parent_sequence_ids = cache_data.sequence_ids
+
+    # Build padded causal mask
+    mask = torch.ones(
+        bsize,
+        1,
+        inputs.size(1),
+        inputs.size(1),
+        device=inputs.device,
+    )
+    mask = mask.tril()  # b 1 n n
+
+    # Mask off any left-pads
+    pad_mask = torch.arange(mask.size(3), device=mask.device).view(
+        1, 1, 1, -1
+    )  # 1 1 1 n
+    pad_mask = pad_mask.expand(bsize, 1, 1, -1)  # b 1 1 n
+    pad_mask = pad_mask.sub(n_pads.sub(1).view(-1, 1, 1, 1)).clamp(0, 1)
+    eye = torch.eye(mask.size(3), device=mask.device)[None, None, :, :]  # 1 1 n n
+    mask = mask.mul(pad_mask).logical_or(eye).log()  # b 1 n n
+
+    # Handle position_ids
+    pos_ids = torch.arange(mask.size(3), device=inputs.device).repeat(bsize, 1)  # b n
+    pos_ids -= n_pads[:, None]
+
+    kwargs: MutableMapping[str, Any] = dict()
+    kwargs["use_cache"] = True
+
+    # Build kv cache and get initial state vector
+    inp_len = speculator.n_predict + 1
+    inputs = inputs[:, -max_seq_len + inp_len :]
+    position_ids = cache_data.compute_position_ids(num_tokens_per_sequence)
+    output = model(
+        inputs,
+        position_ids=position_ids,
+        mask=mask,
+        cache_data=cache_data,
+        return_embeds=True,
+        **kwargs
+    )
+    logits, _, embeds = output
+    embeds = embeds[:, -1:]  # b 1 d
+    logits = logits[:, -1:]  # b 1 v
+
+    n_gen = torch.zeros(bsize, device=inputs.device, dtype=torch.int)
+    n_steps = 0
+    input_ids = torch.argmax(logits, dim=2)  # b 1
+    result = [
+        torch.cat((line, input_id), dim=0)
+        for line, input_id in zip(result, list(input_ids))
+    ]
+    block_mapping_max = ((max_len + new_tokens) // 16) + 1
+    start_time = time.time()
+    while min(n_gen) < new_tokens:
+        n_steps += 1
+
+        # create candidate sequences
+        child_sequence_ids_list = []
+        child_sequence_ids_flattened = []
+        num_tokens_per_sequence = [
+            inp_len for _ in range(input_ids.size(0) * n_candidates)
+        ]
+        # each parent will have n_candidates child sequences
+        for parent_sequence_id in parent_sequence_ids:
+            child_sequence_ids = kv_cache_manager.add_child_sequences(
+                parent_sequence_id, n_candidates
+            )
+            child_sequence_ids_list.append(child_sequence_ids)
+            child_sequence_ids_flattened.extend(child_sequence_ids)
+
+        # add inp_len tokens to each candidate
+        cache_data = kv_cache_manager.allocate_tokens(
+            num_tokens_per_sequence, child_sequence_ids_flattened
+        )
+        position_ids = cache_data.compute_position_ids(num_tokens_per_sequence)
+
+        # Get candidate set of speculations
+        suffix_ids = speculator.generate_suffixes(
+            embeds, input_ids, threshes, n_candidates
+        )  # b k h
+        input_ids = torch.cat(
+            [input_ids.unsqueeze(1).expand(bsize, n_candidates, 1), suffix_ids], dim=-1
+        ).int()  # b k 1+h
+
+        # Apply batch flattening / tree attention if compression is good enough
+        this_flatting = False
+        if flatting:
+            flat_inputs, unflat_indices, flat_indices = flatten_batch(
+                input_ids
+            )  # n', b k 1+h, n'
+            compression = flat_inputs.numel() / input_ids.numel()
+            if compression < 0.75:
+                this_flatting = True
+                flat_inputs = flat_inputs[None,]  # 1 n'
+                cache_data.unflatten_indices = unflat_indices
+                cache_data.flatten_indices = flat_indices
+                position_ids = select_inflate_dim(position_ids.view(-1), flat_indices)[
+                    None,
+                ]
+        input_ids = input_ids.view(-1, inp_len)  # bk 1+h
+
+        # Set up kv cache metadata for paged memory access over tokens/candidates with shared prefixes
+        context_lengths = cache_data.context_lengths  # bk
+        inflate_factor = (
+            cache_data.query_length
+            if cache_data.unflatten_indices is None
+            else cache_data.unflatten_indices.size(-1)
+        )
+        # no reason to check type here as generation allocation always returns context_lengths
+        context_lengths = context_lengths.unsqueeze(1).expand(  # type: ignore
+            -1, inflate_factor
+        )  # bk n
+        # subtract arange(inp_len) to get lengths for each token in candidates
+        context_lengths = (
+            context_lengths.sub(context_lengths.sign().cumsum(1).flip([1]).sub(1))
+            .int()
+            .view(-1)
+        )  # bkn
+        block_mappings = cache_data.block_mapping.repeat_interleave(
+            inflate_factor, dim=0
+        )  # bkn n_blocks
+        # If batch is flattened, flatten corresponding metadata too
+        if cache_data.flatten_indices is not None:
+            context_lengths = select_inflate_dim(
+                context_lengths, cache_data.flatten_indices
+            )  # n'
+            block_mappings = select_inflate_dim(
+                block_mappings, cache_data.flatten_indices
+            )  # n' n_blocks
+
+        # todo: This is a WIP to enable cudagraphs, currently its only for batch_size=1
+        if cudagraphs:
+            # pad for cudagraphs
+            block_mappings = torch.stack(
+                [
+                    F.pad(
+                        block_mappings[i],
+                        (0, block_mapping_max - block_mappings.size(1)),
+                    )
+                    for i in range(block_mappings.size(0))
+                ]
+            )
+
+        cache_data.block_mapping = block_mappings
+        cache_data.context_lengths = context_lengths
+
+        input_ids_unflat = input_ids.view(bsize, n_candidates, inp_len)
+        if this_flatting:
+            input_ids = flat_inputs
+
+        # Base model forward pass
+        output = decode_model(
+            input_ids,
+            position_ids=position_ids,
+            cache_data=cache_data,
+            return_embeds=True,
+            **kwargs
+        )  # 1 n' v  OR  bk 1+h v
+        logits, _, embeds = output  # 1 n' v, 1 n' d  OR  bk 1+h v, bk 1+h d
+        next_vals = torch.argmax(logits, dim=-1)  # 1 n'  OR  bk 1+h
+
+        # If we used batch flattening / tree attention, unflatten the outputs
+        if this_flatting:
+            next_vals = select_inflate_dim(next_vals[0], unflat_indices)  # b k 1+h
+            embeds = select_inflate_dim(embeds[0], unflat_indices)  # b k 1+h d
+        else:
+            next_vals = next_vals.view(bsize, n_candidates, inp_len)  # b k 1+h
+            embeds = embeds.view(
+                bsize, n_candidates, inp_len, embeds.size(2)
+            )  # b k 1+h d
+
+        # Check correctness of speculator predictions
+        test = input_ids_unflat[:, :, 1:].eq(next_vals[:, :, :-1]).cumprod(2)
+        n_correct = test.sum(2).view(bsize, n_candidates)
+        best_guess = n_correct.argmax(1)  # b
+        best_guess_unflat = (
+            best_guess.unsqueeze(1).expand(bsize, inp_len).unsqueeze(1)
+        )  # b 1 1+h
+
+        # Set global values to those of best guess
+        next_vals = next_vals.gather(1, best_guess_unflat).squeeze(1)  # b 1+h
+        n_correct = n_correct.gather(1, best_guess.unsqueeze(1)).squeeze(1)  # b
+        embeds = embeds.gather(
+            1, best_guess_unflat.unsqueeze(3).expand(-1, -1, -1, embeds.size(3))
+        ).squeeze(
+            1
+        )  # b 1+h d
+
+        # free all non-best candidates and keep best candidates as parents
+        parent_sequence_ids = []
+        for parent_index, child_sequence_ids in enumerate(child_sequence_ids_list):
+            best_index = int(best_guess[parent_index].item())
+
+            # free all bad candidates
+            kv_cache_manager.free_sequences(
+                child_sequence_ids[:best_index] + child_sequence_ids[best_index + 1 :]
+            )
+
+            # decrease the context length of the sequence which used to be sequence length + inp_len by the number of incorrect tokens
+            # for the best candidate
+            best_sequence_id = child_sequence_ids[best_index]
+            parent_sequence_ids.append(best_sequence_id)
+            kv_cache_manager.remove_tokens(
+                best_sequence_id, inp_len - n_correct[parent_index].item() - 1
+            )
+
+        # Remove any wrong speculator tokens from best candidate
+        next_vals_split = list(next_vals)
+        next_vals_split = [
+            next_vals_split[i][: n_correct[i] + 1] for i in range(len(next_vals_split))
+        ]  # [b] h'
+        n_gen += n_correct + 1
+        embeds = embeds.gather(
+            1, n_correct.view(-1, 1, 1).expand(-1, -1, embeds.size(2))
+        )  # Grab last correct embed
+
+        # Update results
+        result = [
+            torch.cat((result[i], next_vals_split[i]), dim=0) for i in range(bsize)
+        ]
+        input_ids = torch.stack([line[-1:] for line in next_vals_split], dim=0)  # b 1
+
+    kv_cache_manager.free_sequences(parent_sequence_ids, recursive=True)
+    end_time = time.time()
+    return result, n_steps, (end_time - start_time)
 
 
 def paged_generate(


### PR DESCRIPTION
This PR is the final PR in a stack of PRs related to paged attention + speculative decoding:

- [ ] Paged Attention KVCache (https://github.com/foundation-model-stack/fms-extras/pull/8)
- [ ] Paged Model (https://github.com/foundation-model-stack/fms-extras/pull/9)
- [ ] Speculative generation

Full implementation of the above can be found here: https://github.com/foundation-model-stack/fms-extras/pull/7

In this PR, we have added a speculative_generate function which performs speculative generation on the PagedLLaMA model using an MLPSpeculator. The scripts have also been updated to include a speculator_path in the case a user would like to perform speculative generate. Lastly, 2 functions were added to handle batch flattening/expansion and the attend function has been updated in the case the inputs have been flattened.