### PR TITLE
MLPSpeculator as PretrainedModel

### DIFF
--- a/fms_extras/models/hf/modeling_mlp_speculator.py
+++ b/fms_extras/models/hf/modeling_mlp_speculator.py
@@ -1,0 +1,45 @@
+from typing import List, Optional
+
+from transformers import GenerationConfig, PretrainedConfig, PreTrainedModel
+
+from fms_extras.models.speculator import MLPSpeculator
+
+
+class MLPSpeculatorConfig(PretrainedConfig):
+    model_type = "mlp_speculator"
+
+    attribute_map = {
+        "hidden_size": "emb_dim",
+    }
+
+    def __init__(
+        self,
+        vocab_size: int = 32000,
+        emb_dim: int = 4096,
+        inner_dim: int = 0,
+        n_predict: int = 3,
+        top_k_tokens_per_head: List[int] = [5, 4, 3],
+        n_candidates: int = 5,
+        **kwargs
+    ):
+        assert len(top_k_tokens_per_head) == n_predict
+        self.vocab_size = vocab_size
+        self.emb_dim = emb_dim
+        self.inner_dim = inner_dim
+        self.n_predict = n_predict
+        self.top_k_tokens_per_head = top_k_tokens_per_head
+        self.n_candidates = n_candidates
+        super().__init__(**kwargs)
+
+
+class MLPSpeculatorPreTrainedModel(MLPSpeculator, PreTrainedModel):
+    config_class = MLPSpeculatorConfig
+
+    def __init__(self, config: MLPSpeculatorConfig):
+        super().__init__(
+            config=config,
+            emb_dim=config.emb_dim,
+            inner_dim=config.inner_dim,
+            vocab_size=config.vocab_size,
+            n_predict=config.n_predict,
+        )

--- a/fms_extras/models/speculator.py
+++ b/fms_extras/models/speculator.py
@@ -32,8 +32,10 @@ class MLPSpeculator(nn.Module):
         Number of heads / number of tokens to guess ahead. Model size and speed scale with this value.
     """
 
-    def __init__(self, emb_dim=4096, inner_dim=0, vocab_size=32000, n_predict=3):
-        super().__init__()
+    def __init__(
+        self, emb_dim=4096, inner_dim=0, vocab_size=32000, n_predict=3, *args, **kwargs
+    ):
+        super().__init__(*args, **kwargs)
         self.n_predict = n_predict
         self.emb_dim = emb_dim
         inner_dim = inner_dim if inner_dim != 0 else emb_dim


### PR DESCRIPTION
For loading and saving the model when used for inference, a huggingface PretrainedModel will be required. This PR adds a PretrainedModel and PreTrainedConfig for MLPSpeculator

Load model from raw weights:

```python
weights = torch.load("/path/to/weights", map_location="cuda")["model_state"]
config = MLPSpeculatorConfig(...)
speculator = MLPSpeculatorPreTrainedModel(config)
speculator.load_state_dict(weights)
```

Loading the model if already saved as huggingface:

```python
speculator = MLPSpeculatorPreTrainedModel.from_pretrained("/path/to/speculator")
```

Saving the model:

```python
speculator.save_pretrained("/path/to/speculator")
```